### PR TITLE
Move requireNativeComponent call below the complete MapView definition

### DIFF
--- a/docs/NativeComponentsIOS.md
+++ b/docs/NativeComponentsIOS.md
@@ -87,8 +87,6 @@ class MapView extends React.Component {
   }
 }
 
-var RCTMap = requireNativeComponent('RCTMap', MapView);
-
 MapView.propTypes = {
   /**
    * When this property is set to `true` and a valid camera is associated
@@ -99,6 +97,8 @@ MapView.propTypes = {
    */
   pitchEnabled: React.PropTypes.bool,
 };
+
+var RCTMap = requireNativeComponent('RCTMap', MapView);
 
 module.exports = MapView;
 ```


### PR DESCRIPTION
requireNativeComponent should be called after the wrapper component is fully defined, including its static properties.
